### PR TITLE
fix(flyway): divide sql & add conversation_file table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM adoptopenjdk:8-jdk-hotspot AS builder
+
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle.kts .
+COPY settings.gradle.kts .
+COPY src src
+
+RUN chmod +x ./gradlew
+
+RUN ./gradlew bootJar
+
+FROM adoptopenjdk:8-jdk-hotspot
+COPY --from=builder build/libs/*.jar app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-server", "-Djava.security.egd=file:/dev/./urandom", "-Dspring.config.location=classpath:/config/", "-Dspring.profiles.active=prod", "-jar", "/app.jar"]
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,3 +15,4 @@ services:
     volumes:
       - ./db/mysql/data:/var/lib/mysql
       - ./db/mysql/init:/docker-entrypoint-initdb.d
+    command: ['mysqld', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -4,7 +4,7 @@ create table conversation (
     updated_date datetime not null,
     conversation_time datetime,
     message longtext,
-    member_id bigint,
+    user_id varchar(255),
     primary key (id)
 );
 
@@ -15,32 +15,13 @@ create table reply (
     updated_date datetime not null,
     message longtext,
     reply_time datetime,
-    member_id bigint,
+    user_id varchar(255),
     conversation_id bigint,
     primary key (id)
 );
 
-create table member (
-    id bigint not null auto_increment,
-    created_date datetime not null,
-    updated_date datetime not null,
-    avatar longtext,
-    display_name varchar(255),
-    member_id varchar(255) not null,
-    primary key (id)
-);
-
-alter table conversation
-    add constraint fk_conversation_member
-    foreign key (member_id)
-    references member (id);
 
 alter table reply
     add constraint fk_reply_conversation
     foreign key (conversation_id)
     references conversation (id);
-
-alter table reply
-   add constraint fk_reply_member
-   foreign key (member_id)
-   references member (id);

--- a/src/main/resources/db/migration/V2__add_member.sql
+++ b/src/main/resources/db/migration/V2__add_member.sql
@@ -1,0 +1,43 @@
+ALTER TABLE conversation CHANGE user_id member_id bigint;
+
+ALTER TABLE reply CHANGE user_id member_id bigint;
+
+create table member (
+    id bigint not null auto_increment,
+    created_date datetime not null,
+    updated_date datetime not null,
+    avatar longtext,
+    display_name varchar(255),
+    member_id varchar(255) not null,
+    primary key (id)
+);
+
+create table conversation_file (
+    conversation_id bigint not null,
+    url varchar(255)
+);
+
+create table reply_file (
+    reply_id bigint not null,
+    url varchar(255)
+);
+
+alter table conversation
+    add constraint fk_conversation_member
+    foreign key (member_id)
+    references member (id);
+
+alter table reply
+   add constraint fk_reply_member
+   foreign key (member_id)
+   references member (id);
+
+alter table conversation_file
+    add constraint fk_file_conversation
+    foreign key (conversation_id)
+    references conversation (id);
+
+alter table reply_file
+    add constraint fk_file_reply
+    foreign key (reply_id)
+    references reply (id);


### PR DESCRIPTION
1. [flyway 사용법](https://github.com/woowacourse/archive/issues/9)을 확인하시는게 좋을거 같네요. resources/scheme.sql이나 data.sql 같은 용도와는 달라요. 운영환경의 DB 버전관리를 위한거라, 스키마가 기존과 변경이 된다면 SQL을 통해 기존 데이터 수정을 진행해주어야 합니다.

2. conversation_file 등 몇개 테이블이 누락되어 있던데요. 급하더라도 이런 부분은 기본이라고 생각해요

3. member 테이블에 기본적인 유저 정보가 있어야 하는데요. 혹시 테스트용 데이터는 어떻게 마련했던걸까요?

4. front 빌드 결과와 npm run serve 의 결과가 다르네요 (?)
- [front 빌드결과](http://techcourse-archive-web.s3-website.ap-northeast-2.amazonaws.com/)
- [npm run serve](http://13.125.221.207/)
<img width="540" alt="스크린샷 2020-07-27 오전 6 51 27" src="https://user-images.githubusercontent.com/46308585/88490309-b92ded80-cfd5-11ea-9351-a1e3787aa5a6.png">

5. 배포 서버 접속 정보
- 오늘 저희 코치들이 워크샵 간다는걸 깜박했네요 ㄷㄷ 우선 배포 서버를 임시로 열어둘게요. 급하게 bastion 서버를 구성해두었어요

```
1. bastion 서버 접근 (루터회관에서만 접근 가능합니다. 다른 곳에서 접근 필요시에 요청해주세요)
$ ssh service_user@3.34.177.65 (이 계정은 배포라인 구성되면 제거할게요 :(
passwd : 1q2w3e4r!

2. bastion 서버에서 archive 서비스 서버로 접근
service_user@ip-192-168-0-159:~$ ssh ubuntu@archive
```

- 파일 경로
techcourse/archive/ : archive 백엔드 서버
techcourse/archive-client/ : archive 프론트엔드 서버 (위의 4번 항목이 해결되면 S3 의 techcourse-archive-web 에 정적 파일을 배포할 계획입니다)
techcourse/nginx/ : reverse-proxy 서버

- 현재 네트워크 구성
http://13.125.221.207/ 으로 접근시 rerverse proxy가 서버 로컬의 4000 port의 프론트엔드 서버로 전달함 
프론트엔드 서버는 서버 로컬의 8000 port의 백엔드 서버로 전달함
백엔드 서버는 RDS의 DB와 통신함

- 현재 백엔드 서버는 임시로 도커 이미지를 띄워두었습니다.  

6. 흠.. 최신 버전을 배포해두었는데, 시간 데이터 변환하는 부분에러 예외가 터지네요.. 킁..
